### PR TITLE
chore: [TEAMS-3737] Renamed video server recording ldap attribute

### DIFF
--- a/src/updates/attrs/1656290447.json
+++ b/src/updates/attrs/1656290447.json
@@ -1,5 +1,5 @@
 {
   "zimbra_defaultcos": [
-    "carbonioChatsVideoServerRecordingEnabled"
+    "carbonioVideoServerRecordingEnabled"
   ]
 }


### PR DESCRIPTION
Renamed **carbonioChatsVideoServerRecordingEnabled** attribute into **carbonioVideoServerRecordingEnabled**.
This is made to not link the product name with the ldap attribute directly. So, even if we will decide to change the product name in the future, we can still use the attribute correctly.