### PR TITLE
fix: properly set the build version

### DIFF
--- a/build-common.xml
+++ b/build-common.xml
@@ -174,21 +174,22 @@
   </condition>
 
   <target depends="carbonio-version" name="require-version">
-    <echo message="Using version ${zimbra.buildinfo.version}" />
     <property name="zimbra.buildinfo.version" value="${carbonio.buildinfo.version}" />
+    <echo message="Using version ${zimbra.buildinfo.version}" />
   </target>
+
 
   <target name="carbonio-version">
     <fail message="Missing build version. use ant proper ZCS version like -Dcarbonio.buildinfo.version=23.1.0_ZEXTRAS_202301">
       <condition>
         <not>
-          <isset property="carbonio.buildinfo.version" />
+          <isset property="carbonio.buildinfo.version"/>
         </not>
       </condition>
     </fail>
   </target>
 
-  <target name="set-dev-version" depends="require-version,3rd-party-defines">
+  <target name="set-dev-version" depends="require-version, 3rd-party-defines">
     <antcontrib:if>
       <not>
         <isset property="jar.file" />

--- a/build.xml
+++ b/build.xml
@@ -287,7 +287,7 @@
     <antcall target="start-zimbra" />
   </target>
 
-  <target name="build-dist" depends="generate-ldap-config">
+  <target name="build-dist" depends="set-dev-version, generate-ldap-config">
     <copy todir="${build-dist}" overwrite="true">
       <fileset dir="${build.dir}/ldap-config" />
     </copy>


### PR DESCRIPTION
**What has changed:**
- set-dev-version ant task that is responsible for setting and parsing the carbonio-buildinfo for build is now a mandatory step
- re-arragement of few ant tasks to properly set carbonio-buildinfo property