### PR TITLE
chore: [CO-513] Update default values for Mta Smtpd attributes

### DIFF
--- a/src/updates/attrs/1674157658.json
+++ b/src/updates/attrs/1674157658.json
@@ -1,5 +1,8 @@
 {
   "zimbra_globalconfig": [
-    "carbonioLogoUrl"
+    "zimbraMtaSmtpdRejectUnlistedRecipient",
+    "zimbraMtaSmtpdRejectUnlistedSender",
+    "zimbraMtaSmtpdSenderRestrictions",
+    "zimbraMtaSmtpdSenderLoginMaps"
   ]
 }


### PR DESCRIPTION
**What has changed:**
- update default value of the following attributes
    - zimbraMtaSmtpdRejectUnlistedRecipient
    - zimbraMtaSmtpdRejectUnlistedSender
    - zimbraMtaSmtpdSenderRestrictions
    - zimbraMtaSmtpdSenderLoginMaps

**Other PRs:** 
- https://github.com/Zextras/carbonio-mailbox/pull/151
- https://github.com/Zextras/carbonio-mta/pull/2