### PR TITLE
feat: [CO-568] migration for argon2 support

### DIFF
--- a/conf/ldap/config/cn=config/cn=module{0}.ldif
+++ b/conf/ldap/config/cn=config/cn=module{0}.ldif
@@ -10,6 +10,7 @@ olcModuleLoad: {4}dynlist.la
 olcModuleLoad: {5}unique.la
 olcModuleLoad: {6}noopsrch.la
 olcModuleLoad: {7}pw-sha2.la
+olcModuleLoad: {8}pw-argon2.la
 structuralObjectClass: olcModuleList
 entryUUID: 1525c980-333e-102d-86f6-d562901af228
 creatorsName: cn=config

--- a/conf/ldap/config/cn=config/olcDatabase={-1}frontend.ldif
+++ b/conf/ldap/config/cn=config/olcDatabase={-1}frontend.ldif
@@ -10,7 +10,7 @@ olcMaxDerefDepth: 0
 olcReadOnly: FALSE
 olcSchemaDN: cn=Subschema
 olcMonitoring: FALSE
-olcPasswordHash: {SSHA512}
+olcPasswordHash: {ARGON2}
 structuralObjectClass: olcDatabaseConfig
 entryUUID: 152a840c-333e-102d-86fd-d562901af228
 creatorsName: cn=config

--- a/src/ldap/migration/migrate20230217-AddArgon2.pl
+++ b/src/ldap/migration/migrate20230217-AddArgon2.pl
@@ -1,0 +1,50 @@
+#!/usr/bin/perl
+
+# SPDX-FileCopyrightText: 2022 Synacor, Inc.
+# SPDX-FileCopyrightText: 2022 Zextras <https://www.zextras.com>
+#
+# SPDX-License-Identifier: GPL-2.0-only
+
+use strict;
+use lib '/opt/zextras/common/lib/perl5';
+use Net::LDAP;
+use XML::Simple;
+
+if ( ! -d "/opt/zextras/common/etc/openldap/schema" ) {
+  print STDERR "ERROR: openldap does not appear to be installed - exiting\n";
+  exit(1);
+}
+
+my $id = getpwuid($<);
+chomp $id;
+if ($id ne "zextras") {
+    print STDERR "Error: must be run as zextras user\n";
+    exit (1);
+}
+
+
+my $localxml = XMLin("/opt/zextras/conf/localconfig.xml");
+my $ldap_root_password = $localxml->{key}->{ldap_root_password}->{value};
+chomp($ldap_root_password);
+
+my $ldap = Net::LDAP->new('ldapi://%2fopt%2fzextras%2fdata%2fldap%2fstate%2frun%2fldapi/') or die "$@";
+
+my $mesg = $ldap->bind("cn=config", password=>"$ldap_root_password");
+
+$mesg->code && die "Bind: ". $mesg->error . "\n"; 
+
+my $dn="cn=module{0},cn=config";
+
+$mesg = $ldap->modify(
+    $dn,
+    add =>{olcModuleLoad => 'pw-argon2.la'},
+  );
+
+$dn = 'olcDatabase={-1}frontend, cn=config';
+$mesg = $ldap->modify(
+    $dn,
+    replace=>{olcPasswordHash=>"{ARGON2}"},
+);
+    
+
+$ldap->unbind;


### PR DESCRIPTION
Adds perl migration file to enable argon2 module and password algorithm.