### PR TITLE
feat: [CO-536] update ReverseProxyResponseHeaders

### DIFF
--- a/src/updates/attrs/1677585425.json
+++ b/src/updates/attrs/1677585425.json
@@ -1,0 +1,6 @@
+{
+  "zimbra_globalconfig": [
+    "zimbraReverseProxyResponseHeaders"
+  ]
+}
+


### PR DESCRIPTION
**What has changed:**
- add migration to update defafult values of ReverseProxyResponseHeaders in globalConfig

**Other PRs:**
- https://github.com/Zextras/carbonio-mailbox/pull/168
- https://github.com/Zextras/carbonio-nginx-conf/pull/50