### PR TITLE
fix(CO-693): carbonio.log not showing rewrite errors

### DIFF
--- a/conf/zmconfigd.cf
+++ b/conf/zmconfigd.cf
@@ -341,20 +341,6 @@ SECTION service
 	REWRITE mailboxd/etc/service.web.xml.in mailboxd/webapps/service/WEB-INF/web.xml
 	RESTART mailboxd
 
-SECTION zimbra
-	REWRITE mailboxd/etc/zimbra.web.xml.in mailboxd/webapps/zimbra/WEB-INF/web.xml
-	REWRITE mailboxd/etc/jetty-env.xml.in mailboxd/webapps/zimbra/WEB-INF/jetty-env.xml
-	RESTART mailboxd
-
-SECTION zimbraAdmin
-	REWRITE mailboxd/etc/zimbraAdmin.web.xml.in mailboxd/webapps/zimbraAdmin/WEB-INF/web.xml
-	REWRITE mailboxd/etc/zimbraAdmin-jetty-env.xml.in mailboxd/webapps/zimbraAdmin/WEB-INF/jetty-env.xml
-	RESTART mailboxd
-
-SECTION zimlet
-	REWRITE mailboxd/etc/zimlet.web.xml.in mailboxd/webapps/zimlet/WEB-INF/web.xml
-	RESTART mailboxd
-
 SECTION proxy
 	LOCAL ldap_url
 	MAPLOCAL zimbraSSLDHParam


### PR DESCRIPTION
Remove section that was the cause for errors to be shown.
Tested on nbm-02 where you can check it out looking at the logs while restating the whole mail server via `zmcontrol restart`