### PR TITLE
feat: [CO-703] Use latest mailbox integration for building

### DIFF
--- a/build-ivysettings.xml
+++ b/build-ivysettings.xml
@@ -15,13 +15,12 @@
 
   <settings defaultResolver="chain-resolver" />
   <caches defaultCacheDir="${dev.home}/.ivy2/cache" />
+  <property name="m2-pattern" value="${user.home}/.m2/repository/[organisation]/[module]/[revision]/[module]-[revision](-[classifier]).[ext]" override="false" />
   <resolvers>
     <chain name="chain-resolver" returnFirst="true">
-      <filesystem name="local">
-        <artifact pattern="${dev.home}/.zcs-deps/[organisation]/[module]/[module]-[revision].[ext]" />
-        <artifact pattern="${dev.home}/.zcs-deps/[organisation]-[revision].[ext]" />
-        <artifact pattern="${dev.home}/.zcs-deps/[organisation].[ext]" />
-
+      <filesystem name="local-maven2" m2compatible="true" >
+          <artifact pattern="${m2-pattern}"/>
+          <ivy pattern="${m2-pattern}"/>
       </filesystem>
       <url name="maven-https-org">
         <artifact pattern="https://repo1.maven.org/maven2/[organization]/[module]/[revision]/[artifact]-[revision].[ext]" />

--- a/ivy.xml
+++ b/ivy.xml
@@ -6,14 +6,16 @@ SPDX-FileCopyrightText: 2022 Zextras <https://www.zextras.com>
 SPDX-License-Identifier: AGPL-3.0-only
 -->
 
-<ivy-module version="2.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://ant.apache.org/ivy/schemas/ivy.xsd">
-    <info organisation="zimbra" module="zm-ldap-utilities" status="integration"></info>
+<ivy-module version="2.0" xmlns:maven="http://maven.apache.org" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://ant.apache.org/ivy/schemas/ivy.xsd">
+    <info organisation="zextras" module="zm-ldap-utilities" status="integration"></info>
     <dependencies>
-        <dependency org="zimbra" name="zm-common" rev="latest.integration" />
-        <dependency org="zimbra" name="zm-soap" rev="latest.integration" />
-        <dependency org="zimbra" name="zm-client" rev="latest.integration" />
-        <dependency org="zimbra" name="zm-native" rev="latest.integration" />
-        <dependency org="zimbra" name="zm-store" rev="latest.integration" />
+        <dependency org="zextras" name="zm-common" rev="latest.integration" />
+        <dependency org="zextras" name="zm-soap" rev="latest.integration" />
+        <dependency org="zextras" name="zm-client" rev="latest.integration" />
+        <dependency org="zextras" name="zm-native" rev="latest.integration" />
+        <dependency org="zextras" name="zm-store"  rev="latest.integration" >
+          <artifact name="zm-store" maven:classifier="classes" type="jar" ext="jar"/>
+        </dependency>
         <dependency org="commons-cli" name="commons-cli" rev="1.2" />
         <dependency org="log4j" name="log4j" rev="1.2.16" />
         <dependency org="com.google.guava" name="guava" rev="${com.google.guava.version}" />

--- a/ivy.xml
+++ b/ivy.xml
@@ -10,9 +10,7 @@ SPDX-License-Identifier: AGPL-3.0-only
     <info organisation="zextras" module="zm-ldap-utilities" status="integration"></info>
     <dependencies>
         <dependency org="zextras" name="zm-common" rev="latest.integration" />
-        <dependency org="zextras" name="zm-soap" rev="latest.integration" />
         <dependency org="zextras" name="zm-client" rev="latest.integration" />
-        <dependency org="zextras" name="zm-native" rev="latest.integration" />
         <dependency org="zextras" name="zm-store"  rev="latest.integration" >
           <artifact name="zm-store" maven:classifier="classes" type="jar" ext="jar"/>
         </dependency>


### PR DESCRIPTION
**What has changed:**
- project now uses latest available modules as dependencies from mailbox
- project can also be built locally with latest mailbox integration using local maven repository
- dependencies cleanup: remove `zm-soap` and `zm-native` 