### PR TITLE
feat: [CO-825] add carbonioClamAVReadTimeout

### DIFF
--- a/conf/zmconfigd.cf
+++ b/conf/zmconfigd.cf
@@ -47,6 +47,7 @@ SECTION antivirus DEPENDS amavis
 	VAR zimbraClamAVBindAddress
 	VAR zimbraClamAVDatabaseMirror
 	VAR carbonioClamAVDatabaseCustomURL
+	VAR carbonioClamAVReadTimeout
 	RESTART antivirus mta
 
 SECTION antispam DEPENDS amavis


### PR DESCRIPTION
**What has changed:**
- trigger antivirus restart when carbonioClamAVReadTimeout updated 

**Related PRs:**
- https://github.com/zextras/carbonio-mailbox/pull/355
- https://github.com/zextras/carbonio-mta/pull/8
- https://github.com/zextras/carbonio-amavis/pull/7